### PR TITLE
Add the mac_address field

### DIFF
--- a/apiv4_2/docs/PatchedWritableInterfaceRequest.md
+++ b/apiv4_2/docs/PatchedWritableInterfaceRequest.md
@@ -38,6 +38,7 @@ Name | Type | Description | Notes
 **Vrf** | Pointer to [**NullableIPAddressRequestVrf**](IPAddressRequestVrf.md) |  | [optional] 
 **Tags** | Pointer to [**[]NestedTagRequest**](NestedTagRequest.md) |  | [optional] 
 **CustomFields** | Pointer to **map[string]interface{}** |  | [optional] 
+**MacAddress** | Pointer to **NullableString** |  | [optional] 
 
 ## Methods
 
@@ -1118,6 +1119,41 @@ SetCustomFields sets CustomFields field to given value.
 
 HasCustomFields returns a boolean if a field has been set.
 
+### GetMacAddress
+
+`func (o *PatchedWritableInterfaceRequest) GetMacAddress() string`
+
+GetMacAddress returns the MacAddress field if non-nil, zero value otherwise.
+
+### GetMacAddressOk
+
+`func (o *PatchedWritableInterfaceRequest) GetMacAddressOk() (*string, bool)`
+
+GetMacAddressOk returns a tuple with the MacAddress field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetMacAddress
+
+`func (o *PatchedWritableInterfaceRequest) SetMacAddress(v string)`
+
+SetMacAddress sets MacAddress field to given value.
+
+### HasMacAddress
+
+`func (o *PatchedWritableInterfaceRequest) HasMacAddress() bool`
+
+HasMacAddress returns a boolean if a field has been set.
+
+### SetMacAddressNil
+
+`func (o *PatchedWritableInterfaceRequest) SetMacAddressNil(b bool)`
+
+ SetMacAddressNil sets the value for MacAddress to be an explicit nil
+
+### UnsetMacAddress
+`func (o *PatchedWritableInterfaceRequest) UnsetMacAddress()`
+
+UnsetMacAddress ensures that no value is present for MacAddress, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/apiv4_2/docs/WritableInterfaceRequest.md
+++ b/apiv4_2/docs/WritableInterfaceRequest.md
@@ -38,6 +38,7 @@ Name | Type | Description | Notes
 **Vrf** | Pointer to [**NullableIPAddressRequestVrf**](IPAddressRequestVrf.md) |  | [optional] 
 **Tags** | Pointer to [**[]NestedTagRequest**](NestedTagRequest.md) |  | [optional] 
 **CustomFields** | Pointer to **map[string]interface{}** |  | [optional] 
+**MacAddress** | Pointer to **NullableString** |  | [optional] 
 
 ## Methods
 
@@ -1103,6 +1104,41 @@ SetCustomFields sets CustomFields field to given value.
 
 HasCustomFields returns a boolean if a field has been set.
 
+### GetMacAddress
+
+`func (o *WritableInterfaceRequest) GetMacAddress() string`
+
+GetMacAddress returns the MacAddress field if non-nil, zero value otherwise.
+
+### GetMacAddressOk
+
+`func (o *WritableInterfaceRequest) GetMacAddressOk() (*string, bool)`
+
+GetMacAddressOk returns a tuple with the MacAddress field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetMacAddress
+
+`func (o *WritableInterfaceRequest) SetMacAddress(v string)`
+
+SetMacAddress sets MacAddress field to given value.
+
+### HasMacAddress
+
+`func (o *WritableInterfaceRequest) HasMacAddress() bool`
+
+HasMacAddress returns a boolean if a field has been set.
+
+### SetMacAddressNil
+
+`func (o *WritableInterfaceRequest) SetMacAddressNil(b bool)`
+
+ SetMacAddressNil sets the value for MacAddress to be an explicit nil
+
+### UnsetMacAddress
+`func (o *WritableInterfaceRequest) UnsetMacAddress()`
+
+UnsetMacAddress ensures that no value is present for MacAddress, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/apiv4_2/model_patched_writable_interface_request.go
+++ b/apiv4_2/model_patched_writable_interface_request.go
@@ -58,6 +58,7 @@ type PatchedWritableInterfaceRequest struct {
 	Vrf                  NullableIPAddressRequestVrf `json:"vrf,omitempty"`
 	Tags                 []NestedTagRequest          `json:"tags,omitempty"`
 	CustomFields         map[string]interface{}      `json:"custom_fields,omitempty"`
+	MacAddress           NullableString              `json:"mac_address,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -1399,6 +1400,49 @@ func (o *PatchedWritableInterfaceRequest) SetCustomFields(v map[string]interface
 	o.CustomFields = v
 }
 
+// GetMacAddress returns the MacAddress field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *PatchedWritableInterfaceRequest) GetMacAddress() string {
+	if o == nil || IsNil(o.MacAddress.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.MacAddress.Get()
+}
+
+// GetMacAddressOk returns a tuple with the MacAddress field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *PatchedWritableInterfaceRequest) GetMacAddressOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MacAddress.Get(), o.MacAddress.IsSet()
+}
+
+// HasMacAddress returns a boolean if a field has been set.
+func (o *PatchedWritableInterfaceRequest) HasMacAddress() bool {
+	if o != nil && o.MacAddress.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMacAddress gets a reference to the given NullableString and assigns it to the MacAddress field.
+func (o *PatchedWritableInterfaceRequest) SetMacAddress(v string) {
+	o.MacAddress.Set(&v)
+}
+
+// SetMacAddressNil sets the value for MacAddress to be an explicit nil
+func (o *PatchedWritableInterfaceRequest) SetMacAddressNil() {
+	o.MacAddress.Set(nil)
+}
+
+// UnsetMacAddress ensures that no value is present for MacAddress, not even an explicit nil
+func (o *PatchedWritableInterfaceRequest) UnsetMacAddress() {
+	o.MacAddress.Unset()
+}
+
 func (o PatchedWritableInterfaceRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -1511,6 +1555,9 @@ func (o PatchedWritableInterfaceRequest) ToMap() (map[string]interface{}, error)
 	if !IsNil(o.CustomFields) {
 		toSerialize["custom_fields"] = o.CustomFields
 	}
+	if o.MacAddress.IsSet() {
+		toSerialize["mac_address"] = o.MacAddress.Get()
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -1567,6 +1614,7 @@ func (o *PatchedWritableInterfaceRequest) UnmarshalJSON(data []byte) (err error)
 		delete(additionalProperties, "vrf")
 		delete(additionalProperties, "tags")
 		delete(additionalProperties, "custom_fields")
+		delete(additionalProperties, "mac_address")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/apiv4_2/model_writable_interface_request.go
+++ b/apiv4_2/model_writable_interface_request.go
@@ -59,6 +59,7 @@ type WritableInterfaceRequest struct {
 	Vrf                  NullableIPAddressRequestVrf `json:"vrf,omitempty"`
 	Tags                 []NestedTagRequest          `json:"tags,omitempty"`
 	CustomFields         map[string]interface{}      `json:"custom_fields,omitempty"`
+	MacAddress           NullableString              `json:"mac_address,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -1379,6 +1380,49 @@ func (o *WritableInterfaceRequest) SetCustomFields(v map[string]interface{}) {
 	o.CustomFields = v
 }
 
+// GetMacAddress returns the MacAddress field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *WritableInterfaceRequest) GetMacAddress() string {
+	if o == nil || IsNil(o.MacAddress.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.MacAddress.Get()
+}
+
+// GetMacAddressOk returns a tuple with the MacAddress field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *WritableInterfaceRequest) GetMacAddressOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MacAddress.Get(), o.MacAddress.IsSet()
+}
+
+// HasMacAddress returns a boolean if a field has been set.
+func (o *WritableInterfaceRequest) HasMacAddress() bool {
+	if o != nil && o.MacAddress.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMacAddress gets a reference to the given NullableString and assigns it to the MacAddress field.
+func (o *WritableInterfaceRequest) SetMacAddress(v string) {
+	o.MacAddress.Set(&v)
+}
+
+// SetMacAddressNil sets the value for MacAddress to be an explicit nil
+func (o *WritableInterfaceRequest) SetMacAddressNil() {
+	o.MacAddress.Set(nil)
+}
+
+// UnsetMacAddress ensures that no value is present for MacAddress, not even an explicit nil
+func (o *WritableInterfaceRequest) UnsetMacAddress() {
+	o.MacAddress.Unset()
+}
+
 func (o WritableInterfaceRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -1485,6 +1529,9 @@ func (o WritableInterfaceRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CustomFields) {
 		toSerialize["custom_fields"] = o.CustomFields
 	}
+	if o.MacAddress.IsSet() {
+		toSerialize["mac_address"] = o.MacAddress.Get()
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -1580,6 +1627,7 @@ func (o *WritableInterfaceRequest) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "vrf")
 		delete(additionalProperties, "tags")
 		delete(additionalProperties, "custom_fields")
+		delete(additionalProperties, "mac_address")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/patcher/pre_gen.py
+++ b/patcher/pre_gen.py
@@ -109,6 +109,11 @@ def patch_spec(data):
                     }
                     if "required" in schema:
                         schema["required"] = [prop for prop in schema["required"] if prop != "mac_addresses"]
+                if name in ["WritableInterfaceRequest", "PatchedWritableInterfaceRequest"]:
+                    schema["properties"]["mac_address"] = {
+                        "type": "string",
+                        "nullable": True,
+                    }
 
     return data
 

--- a/schemas/patched-4.2.6.yaml
+++ b/schemas/patched-4.2.6.yaml
@@ -146080,6 +146080,9 @@ components:
         custom_fields:
           type: object
           additionalProperties: {}
+        mac_address:
+          type: string
+          nullable: true
     PatchedWritableInterfaceTemplateRequest:
       type: object
       description: 'Extends the built-in ModelSerializer to enforce calling full_clean()
@@ -166081,6 +166084,9 @@ components:
         custom_fields:
           type: object
           additionalProperties: {}
+        mac_address:
+          type: string
+          nullable: true
       required:
       - device
       - name


### PR DESCRIPTION
As you did for the objects ```PatchedWritableVMInterfaceRequest``` and ```WritableVMInterfaceRequest```.
I added the ```mac_address``` field to ```PatchedWritableInterfaceRequest``` and ```WritableInterfaceRequest```, so that it is possible to modify the mac address depending on the Netbox version.